### PR TITLE
Update curl to 0.4 to match tokio-curl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["http", "client", "request", "rest", "async", "asynchronous"]
 license = "MIT"
 
 [dependencies]
-curl = "0.3"
+curl = "0.4"
 futures = "0.1"
 mime = "0.2"
 rustc-serialize = { version = "0.3", optional = true }


### PR DESCRIPTION
I was seeing the following error, since tokio-curl updated curl version.

```
error: native library `curl` is being linked to by more than one version of the same package, but it can only be linked once; try updating or pinning your dependencies to ensure that this package only shows up once

  curl-sys v0.3.10
  curl-sys v0.2.5
```